### PR TITLE
[Build error] Build fails with invalid Gstreamer

### DIFF
--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -82,7 +82,7 @@ if (ENABLE_VIDEO)
     set(GSTREAMER_COMPONENTS app audio fft gl pbutils tag video)
     add_definitions(-DWTF_USE_GSTREAMER)
 
-    find_package(GStreamer 1.4.1 REQUIRED COMPONENTS ${GSTREAMER_COMPONENTS})
+    find_package(GStreamer 1.4.2 REQUIRED COMPONENTS ${GSTREAMER_COMPONENTS})
 
     # FIXME: What about MPEGTS support? WTF_USE_GSTREAMER_MPEGTS?
 endif ()


### PR DESCRIPTION
Updates the version to 1.4.2, which is what is being built in step 1. Without it, none of the Gstreamer libraries are found.

However, this results in the following build error (on a Jetson TK1)

```
-- checking for module 'gstreamer-1.0 >= 1.4.2'
--   found gstreamer-1.0 , version 1.4.2
-- checking for module 'gstreamer-base-1.0 >= 1.4.2'
--   found gstreamer-base-1.0 , version 1.4.2
-- checking for module 'gstreamer-app-1.0 >= 1.4.2'
--   found gstreamer-app-1.0 , version 1.4.2
-- checking for module 'gstreamer-audio-1.0 >= 1.4.2'
--   found gstreamer-audio-1.0 , version 1.4.2
-- checking for module 'gstreamer-fft-1.0 >= 1.4.2'
--   found gstreamer-fft-1.0 , version 1.4.2
-- checking for module 'gstreamer-gl-1.0 >= 1.4.2'
--   package 'gstreamer-gl-1.0 >= 1.4.2' not found
-- checking for module 'gstreamer-mpegts-1.0>=1.4.0'
--   found gstreamer-mpegts-1.0, version 1.4.2
-- checking for module 'gstreamer-pbutils-1.0 >= 1.4.2'
--   found gstreamer-pbutils-1.0 , version 1.4.2
-- checking for module 'gstreamer-tag-1.0 >= 1.4.2'
--   found gstreamer-tag-1.0 , version 1.4.2
-- checking for module 'gstreamer-video-1.0 >= 1.4.2'
--   found gstreamer-video-1.0 , version 1.4.2
-- Found GStreamer: GSTREAMER_INCLUDE_DIRS;GSTREAMER_LIBRARIES;GSTREAMER_VERSION;GSTREAMER_BASE_INCLUDE_DIRS;GSTREAMER_BASE_LIBRARIES;GSTREAMER_APP_INCLUDE_DIRS;GSTREAMER_APP_LIBRARIES;GSTREAMER_AUDIO_INCLUDE_DIRS;GSTREAMER_AUDIO_LIBRARIES;GSTREAMER_FFT_INCLUDE_DIRS;GSTREAMER_FFT_LIBRARIES;GSTREAMER_GL_INCLUDE_DIRS;GSTREAMER_GL_LIBRARIES;GSTREAMER_PBUTILS_INCLUDE_DIRS;GSTREAMER_PBUTILS_LIBRARIES;GSTREAMER_TAG_INCLUDE_DIRS;GSTREAMER_TAG_LIBRARIES;GSTREAMER_VIDEO_INCLUDE_DIRS;GSTREAMER_VIDEO_LIBRARIES (Required is at least version "1.4.2")
-- Using platform-specific CMakeLists: /mnt/working/src/webkit/Source/WTF/wtf/PlatformWPE.cmake
-- Using platform-specific CMakeLists: /mnt/working/src/webkit/Source/JavaScriptCore/PlatformWPE.cmake
-- Using platform-specific CMakeLists: /mnt/working/src/webkit/Source/JavaScriptCore/shell/PlatformWPE.cmake
-- Using platform-specific CMakeLists: /mnt/working/src/webkit/Source/WebCore/PlatformWPE.cmake
-- Using platform-specific CMakeLists: /mnt/working/src/webkit/Source/WebKit2/PlatformWPE.cmake
-- Platform-specific CMakeLists not found: /mnt/working/src/webkit/Source/PlatformWPE.cmake
-- Using platform-specific CMakeLists: /mnt/working/src/webkit/Tools/WebKitTestRunner/PlatformWPE.cmake
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
GSTREAMER_GL_LIBRARIES (ADVANCED)
    linked by target "WebCore" in directory /mnt/working/src/webkit/Source/WebCore

-- Configuring incomplete, errors occurred!
See also "/mnt/working/src/webkit/WebKitBuild/Release/CMakeFiles/CMakeOutput.log".
See also "/mnt/working/src/webkit/WebKitBuild/Release/CMakeFiles/CMakeError.log".
```

As far as I can tell, no Gstreamer GL or EGL dependencies are being built in the first step, so I'm stuck here.