### PR TITLE
Add more guards for PLATFORM(GBM).

### DIFF
--- a/Source/WebCore/platform/graphics/GLContext.h
+++ b/Source/WebCore/platform/graphics/GLContext.h
@@ -30,7 +30,9 @@
 #if !PLATFORM(GTK) && !PLATFORM(WPE)
 #include "eglplatform.h"
 #else
+#if PLATFORM(GBM)
 #include <gbm.h>
+#endif
 #include <EGL/eglplatform.h>
 #endif
 typedef EGLNativeWindowType GLNativeWindowType;

--- a/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -166,8 +166,10 @@ void ThreadedCompositor::didChangeViewportSize(const IntSize& size)
 {
     RefPtr<ThreadedCompositor> protector(this);
     callOnCompositingThread([=] {
+#if PLATFORM(GBM)
         if (m_surface)
             m_surface->resize(size);
+#endif
         protector->viewportController()->didChangeViewportSize(size);
     });
 }
@@ -304,8 +306,10 @@ void ThreadedCompositor::renderLayerTree()
 
     glContext()->swapBuffers();
 
+#if PLATFORM(GBM)
     auto bufferExport = m_surface->lockFrontBuffer();
     m_compositingManager.commitPrimeBuffer(bufferExport);
+#endif
 }
 
 void ThreadedCompositor::updateSceneState(const CoordinatedGraphicsState& state)


### PR DESCRIPTION
This fixes build when gbm is not enabled.
There is no other implementation as fallback in this commit, but it allows to add more implementations that do not rely on gbm.