### PR TITLE
Pasteboard

### DIFF
--- a/Source/WPE/CMakeLists.txt
+++ b/Source/WPE/CMakeLists.txt
@@ -30,7 +30,7 @@ set(WPE_INCLUDE_DIRECTORIES
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Input"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard"
-    "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard/Private"
+    "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard/Generic"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard/Wayland"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/ViewBackend"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/ViewBackend/Wayland"
@@ -59,7 +59,8 @@ set(WPE_SOURCES
 
     Source/Pasteboard/Pasteboard.cpp
 
-    Source/Pasteboard/Private/PasteboardPrivate.cpp
+    Source/Pasteboard/Generic/PasteboardGeneric.cpp
+
     Source/ViewBackend/ViewBackend.cpp
 )
 

--- a/Source/WPE/CMakeLists.txt
+++ b/Source/WPE/CMakeLists.txt
@@ -28,6 +28,10 @@ set(WPE_INCLUDE_DIRECTORIES
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Graphics"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Input"
+    "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard"
+    "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard"
+    "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard/Private"
+    "${CMAKE_SOURCE_DIR}/Source/WPE/Source/Pasteboard/Wayland"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/ViewBackend"
     "${CMAKE_SOURCE_DIR}/Source/WPE/Source/ViewBackend/Wayland"
     ${GLIB_INCLUDE_DIRS}
@@ -53,6 +57,9 @@ set(WPE_SOURCES
     Source/Input/XKB/KeyMappingXKB.cpp
     Source/Input/XKB/KeyboardEventHandlerXKB.cpp
 
+    Source/Pasteboard/Pasteboard.cpp
+
+    Source/Pasteboard/Private/PasteboardPrivate.cpp
     Source/ViewBackend/ViewBackend.cpp
 )
 
@@ -85,6 +92,7 @@ endif ()
 
 if (USE_WPE_BACKEND_WAYLAND)
     list(APPEND WPE_SOURCES
+        Source/Pasteboard/Wayland/PasteboardWayland.cpp
         Source/ViewBackend/Wayland/ViewBackendWayland.cpp
         Source/ViewBackend/Wayland/WaylandDisplay.cpp
         Source/ViewBackend/Wayland/ivi-application-protocol.c

--- a/Source/WPE/Headers/WPE/Pasteboard/Pasteboard.h
+++ b/Source/WPE/Headers/WPE/Pasteboard/Pasteboard.h
@@ -41,8 +41,8 @@ public:
 
     virtual std::vector<std::string> getTypes() = 0;
     virtual std::string getString(const std::string) = 0;
-    virtual void write(const std::map<std::string, std::string>) = 0;
-    virtual void write(const std::string, const std::string) = 0;
+    virtual void write(std::map<std::string, std::string>&&) = 0;
+    virtual void write(std::string&&, std::string&&) = 0;
 };
 
 } // namespace Pasteboard

--- a/Source/WPE/Headers/WPE/Pasteboard/Pasteboard.h
+++ b/Source/WPE/Headers/WPE/Pasteboard/Pasteboard.h
@@ -41,7 +41,7 @@ public:
 
     virtual std::vector<std::string> getTypes() = 0;
     virtual std::string getString(const std::string) = 0;
-    virtual void write(const std::map<std::string, void*>) = 0;
+    virtual void write(const std::map<std::string, std::string>) = 0;
     virtual void write(const std::string, const std::string) = 0;
 };
 

--- a/Source/WPE/Headers/WPE/Pasteboard/Pasteboard.h
+++ b/Source/WPE/Headers/WPE/Pasteboard/Pasteboard.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPE_Pasteboard_Pasteboard_h
+#define WPE_Pasteboard_Pasteboard_h
+
+#include <WPE/WPE.h>
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace WPE {
+
+namespace Pasteboard {
+
+class Pasteboard {
+public:
+    static WPE_EXPORT std::shared_ptr<Pasteboard> singleton();
+
+    virtual std::vector<std::string> getTypes() = 0;
+    virtual std::string getString(const std::string) = 0;
+    virtual void write(const std::map<std::string, void*>) = 0;
+    virtual void write(const std::string, const std::string) = 0;
+};
+
+} // namespace Pasteboard
+
+} // namespace WPE
+
+#endif // WPE_Pasteboard_Pasteboard_h

--- a/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
+++ b/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
@@ -47,13 +47,10 @@ std::string PasteboardGeneric::getString(const std::string pasteboardType)
     if (m_dataMap.count(pasteboardType) == 0)
         return std::string();
 
-    if (pasteboardType == "text/plain;charset=utf-8")
-        return std::string(*static_cast<std::string*>(m_dataMap[pasteboardType]));
-
-    return std::string();
+    return m_dataMap[pasteboardType];
 }
 
-void PasteboardGeneric::write(const std::map<std::string, void*> dataMap)
+void PasteboardGeneric::write(const std::map<std::string, std::string> dataMap)
 {
     m_dataMap = dataMap;
 
@@ -62,7 +59,7 @@ void PasteboardGeneric::write(const std::map<std::string, void*> dataMap)
 void PasteboardGeneric::write(const std::string pasteboardType, const std::string stringToWrite)
 {
     m_dataMap.clear();
-    m_dataMap[pasteboardType] = static_cast<void*>(new std::string(stringToWrite));
+    m_dataMap[pasteboardType] = stringToWrite;
 }
 
 } // namespace Pasteboard

--- a/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
+++ b/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
@@ -50,13 +50,12 @@ std::string PasteboardGeneric::getString(const std::string pasteboardType)
     return m_dataMap[pasteboardType];
 }
 
-void PasteboardGeneric::write(const std::map<std::string, std::string> dataMap)
+void PasteboardGeneric::write(std::map<std::string, std::string>&& dataMap)
 {
     m_dataMap = dataMap;
-
 }
 
-void PasteboardGeneric::write(const std::string pasteboardType, const std::string stringToWrite)
+void PasteboardGeneric::write(std::string&& pasteboardType, std::string&& stringToWrite)
 {
     m_dataMap.clear();
     m_dataMap[pasteboardType] = stringToWrite;

--- a/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
+++ b/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
@@ -30,13 +30,9 @@ namespace WPE {
 
 namespace Pasteboard {
 
-PasteboardGeneric::PasteboardGeneric()
-{
-}
+PasteboardGeneric::PasteboardGeneric() = default;
 
-PasteboardGeneric::~PasteboardGeneric()
-{
-}
+PasteboardGeneric::~PasteboardGeneric() = default;
 
 std::vector<std::string> PasteboardGeneric::getTypes()
 {

--- a/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
+++ b/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.cpp
@@ -24,21 +24,21 @@
  */
 
 #include "Config.h"
-#include "PasteboardPrivate.h"
+#include "PasteboardGeneric.h"
 
 namespace WPE {
 
 namespace Pasteboard {
 
-PasteboardPrivate::PasteboardPrivate()
+PasteboardGeneric::PasteboardGeneric()
 {
 }
 
-PasteboardPrivate::~PasteboardPrivate()
+PasteboardGeneric::~PasteboardGeneric()
 {
 }
 
-std::vector<std::string> PasteboardPrivate::getTypes()
+std::vector<std::string> PasteboardGeneric::getTypes()
 {
     std::vector<std::string> types;
     for (auto dataType: m_dataMap)
@@ -46,7 +46,7 @@ std::vector<std::string> PasteboardPrivate::getTypes()
     return types;
 }
 
-std::string PasteboardPrivate::getString(const std::string pasteboardType)
+std::string PasteboardGeneric::getString(const std::string pasteboardType)
 {
     if (m_dataMap.count(pasteboardType) == 0)
         return std::string();
@@ -57,13 +57,13 @@ std::string PasteboardPrivate::getString(const std::string pasteboardType)
     return std::string();
 }
 
-void PasteboardPrivate::write(const std::map<std::string, void*> dataMap)
+void PasteboardGeneric::write(const std::map<std::string, void*> dataMap)
 {
     m_dataMap = dataMap;
 
 }
 
-void PasteboardPrivate::write(const std::string pasteboardType, const std::string stringToWrite)
+void PasteboardGeneric::write(const std::string pasteboardType, const std::string stringToWrite)
 {
     m_dataMap.clear();
     m_dataMap[pasteboardType] = static_cast<void*>(new std::string(stringToWrite));
@@ -72,5 +72,3 @@ void PasteboardPrivate::write(const std::string pasteboardType, const std::strin
 } // namespace Pasteboard
 
 } // namespace WPE
-
-//#endif // WPE_BACKEND(WAYLAND)

--- a/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.h
+++ b/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.h
@@ -37,7 +37,7 @@ class PasteboardGeneric final : public Pasteboard {
 public:
     std::vector<std::string> getTypes() override;
     std::string getString(const std::string) override;
-    void write(const std::map<std::string, void*>) override;
+    void write(const std::map<std::string, std::string>) override;
     void write(const std::string, const std::string) override;
 
     PasteboardGeneric();
@@ -45,7 +45,7 @@ public:
 
 private:
 
-    std::map<std::string, void*> m_dataMap;
+    std::map<std::string, std::string> m_dataMap;
 };
 
 } // namespace Pasteboard

--- a/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.h
+++ b/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.h
@@ -37,8 +37,8 @@ class PasteboardGeneric final : public Pasteboard {
 public:
     std::vector<std::string> getTypes() override;
     std::string getString(const std::string) override;
-    void write(const std::map<std::string, std::string>) override;
-    void write(const std::string, const std::string) override;
+    void write(std::map<std::string, std::string>&&) override;
+    void write(std::string&&, std::string&&) override;
 
     PasteboardGeneric();
     ~PasteboardGeneric();

--- a/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.h
+++ b/Source/WPE/Source/Pasteboard/Generic/PasteboardGeneric.h
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WPE_Pasteboard_PasteboardPrivate_h
-#define WPE_Pasteboard_PasteboardPrivate_h
+#ifndef WPE_Pasteboard_PasteboardGeneric_h
+#define WPE_Pasteboard_PasteboardGeneric_h
 
 #include <WPE/Pasteboard/Pasteboard.h>
 #include <map>
@@ -33,15 +33,15 @@ namespace WPE {
 
 namespace Pasteboard {
 
-class PasteboardPrivate final : public Pasteboard {
+class PasteboardGeneric final : public Pasteboard {
 public:
     std::vector<std::string> getTypes() override;
     std::string getString(const std::string) override;
     void write(const std::map<std::string, void*>) override;
     void write(const std::string, const std::string) override;
 
-    PasteboardPrivate();
-    ~PasteboardPrivate();
+    PasteboardGeneric();
+    ~PasteboardGeneric();
 
 private:
 
@@ -52,4 +52,4 @@ private:
 
 } // namespace WPE
 
-#endif // WPE_ViewBackend_PasteboardPrivate_h
+#endif // WPE_ViewBackend_PasteboardGeneric_h

--- a/Source/WPE/Source/Pasteboard/Pasteboard.cpp
+++ b/Source/WPE/Source/Pasteboard/Pasteboard.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.h"
+#include <WPE/Pasteboard/Pasteboard.h>
+
+#include "PasteboardPrivate.h"
+#if WPE_BACKEND(WAYLAND)
+#include "PasteboardWayland.h"
+#endif
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+
+namespace WPE {
+
+namespace Pasteboard {
+
+std::shared_ptr<Pasteboard> Pasteboard::singleton()
+{
+    auto* backendEnv = std::getenv("WPE_BACKEND");
+
+    static std::shared_ptr<Pasteboard> pasteboard = nullptr;
+
+    if (pasteboard)
+        return pasteboard;
+
+#if WPE_BACKEND(WAYLAND)
+    if (std::getenv("WAYLAND_DISPLAY") || (backendEnv && !std::strcmp(backendEnv, "wayland"))) {
+        pasteboard = std::shared_ptr<PasteboardWayland>(new PasteboardWayland);
+        return pasteboard;
+    }
+#endif
+
+    pasteboard = std::shared_ptr<PasteboardPrivate>(new PasteboardPrivate);
+    return pasteboard;
+}
+
+} // namespace Pasteboard
+
+} // namespace WPE

--- a/Source/WPE/Source/Pasteboard/Pasteboard.cpp
+++ b/Source/WPE/Source/Pasteboard/Pasteboard.cpp
@@ -26,7 +26,7 @@
 #include "Config.h"
 #include <WPE/Pasteboard/Pasteboard.h>
 
-#include "PasteboardPrivate.h"
+#include "PasteboardGeneric.h"
 #if WPE_BACKEND(WAYLAND)
 #include "PasteboardWayland.h"
 #endif
@@ -54,7 +54,7 @@ std::shared_ptr<Pasteboard> Pasteboard::singleton()
     }
 #endif
 
-    pasteboard = std::shared_ptr<PasteboardPrivate>(new PasteboardPrivate);
+    pasteboard = std::shared_ptr<PasteboardGeneric>(new PasteboardGeneric);
     return pasteboard;
 }
 

--- a/Source/WPE/Source/Pasteboard/Private/PasteboardPrivate.cpp
+++ b/Source/WPE/Source/Pasteboard/Private/PasteboardPrivate.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.h"
+#include "PasteboardPrivate.h"
+
+//#if !WPE_BACKEND(WAYLAND)
+
+// #include <algorithm>
+// #include <glib.h>
+// #include <cassert>
+// #include <cstdio>
+// #include <cstring>
+// #include <fcntl.h>
+// #include <memory>
+// #include <unistd.h>
+// #include <wayland-client.h>
+
+namespace WPE {
+
+namespace Pasteboard {
+
+PasteboardPrivate::PasteboardPrivate()
+{
+}
+
+PasteboardPrivate::~PasteboardPrivate()
+{
+    m_dataMap.clear();
+}
+
+std::vector<std::string> PasteboardPrivate::getTypes()
+{
+    std::vector<std::string> types;
+    for (auto dataType: m_dataMap)
+        types.push_back(dataType.first);
+    return types;
+}
+
+std::string PasteboardPrivate::getString(const std::string pasteboardType)
+{
+    if (m_dataMap.count(pasteboardType) == 0)
+        return std::string();
+
+    if (pasteboardType == "text/plain;charset=utf-8")
+        return std::string(*static_cast<std::string*>(m_dataMap[pasteboardType]));
+
+    return std::string();
+}
+
+void PasteboardPrivate::write(const std::map<std::string, void*> dataMap)
+{
+    m_dataMap = dataMap;
+
+}
+
+void PasteboardPrivate::write(const std::string pasteboardType, const std::string stringToWrite)
+{
+    m_dataMap.clear();
+    m_dataMap[pasteboardType] = static_cast<void*>(new std::string(stringToWrite));
+}
+
+} // namespace Pasteboard
+
+} // namespace WPE
+
+//#endif // WPE_BACKEND(WAYLAND)

--- a/Source/WPE/Source/Pasteboard/Private/PasteboardPrivate.cpp
+++ b/Source/WPE/Source/Pasteboard/Private/PasteboardPrivate.cpp
@@ -26,18 +26,6 @@
 #include "Config.h"
 #include "PasteboardPrivate.h"
 
-//#if !WPE_BACKEND(WAYLAND)
-
-// #include <algorithm>
-// #include <glib.h>
-// #include <cassert>
-// #include <cstdio>
-// #include <cstring>
-// #include <fcntl.h>
-// #include <memory>
-// #include <unistd.h>
-// #include <wayland-client.h>
-
 namespace WPE {
 
 namespace Pasteboard {
@@ -48,7 +36,6 @@ PasteboardPrivate::PasteboardPrivate()
 
 PasteboardPrivate::~PasteboardPrivate()
 {
-    m_dataMap.clear();
 }
 
 std::vector<std::string> PasteboardPrivate::getTypes()

--- a/Source/WPE/Source/Pasteboard/Private/PasteboardPrivate.h
+++ b/Source/WPE/Source/Pasteboard/Private/PasteboardPrivate.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPE_Pasteboard_PasteboardPrivate_h
+#define WPE_Pasteboard_PasteboardPrivate_h
+
+#include <WPE/Pasteboard/Pasteboard.h>
+#include <map>
+
+namespace WPE {
+
+namespace Pasteboard {
+
+class PasteboardPrivate final : public Pasteboard {
+public:
+    std::vector<std::string> getTypes() override;
+    std::string getString(const std::string) override;
+    void write(const std::map<std::string, void*>) override;
+    void write(const std::string, const std::string) override;
+
+    PasteboardPrivate();
+    ~PasteboardPrivate();
+
+private:
+
+    std::map<std::string, void*> m_dataMap;
+};
+
+} // namespace Pasteboard
+
+} // namespace WPE
+
+#endif // WPE_ViewBackend_PasteboardPrivate_h

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
@@ -54,7 +54,7 @@ const struct wl_data_offer_listener g_dataOfferListener = {
 };
 
 const struct wl_data_device_listener g_dataDeviceListener = {
-    // data offer
+    // data_offer
     [] (void* data, struct wl_data_device*, struct wl_data_offer* offer)
     {
         auto& dataDeviceData = *static_cast<PasteboardWayland::DataDeviceData*>(data);

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
@@ -141,8 +141,7 @@ const struct wl_data_source_listener g_dataSourceListener = {
         assert(dataSourceData->data_source == source);
         assert(!dataSourceData->dataMap.count(mime_type));
 
-        // FIXME: Should probably do the same for all text mimetypes.
-        if (strcmp(mime_type, "text/plain;charset=utf-8") == 0) {
+        if (strncmp(mime_type, "text/", 5) == 0) {
             std::string stringToSend(*static_cast<std::string*>(dataSourceData->dataMap[mime_type]));
             const char* p = stringToSend.data();
             ssize_t length = stringToSend.size();

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.h"
+#include "PasteboardWayland.h"
+
+#if WPE_BACKEND(WAYLAND)
+
+#include "WaylandDisplay.h"
+#include <algorithm>
+#include <glib.h>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <memory>
+#include <unistd.h>
+#include <wayland-client.h>
+
+namespace WPE {
+
+namespace Pasteboard {
+
+const struct wl_data_offer_listener g_dataOfferListener = {
+    // offer
+    [] (void* data, struct wl_data_offer* offer, const char* type)
+    {
+        auto* dataDeviceData = static_cast<PasteboardWayland::DataDeviceData*>(data);
+        assert(offer == dataDeviceData->data_offer);
+        dataDeviceData->dataTypes.push_back(type);
+    },
+};
+
+const struct wl_data_device_listener g_dataDeviceListener = {
+    // data offer
+    [] (void* data, struct wl_data_device*, struct wl_data_offer* offer)
+    {
+        auto& dataDeviceData = *static_cast<PasteboardWayland::DataDeviceData*>(data);
+
+        dataDeviceData.dataTypes.clear();
+        if (dataDeviceData.data_offer)
+            wl_data_offer_destroy(dataDeviceData.data_offer);
+        dataDeviceData.data_offer = offer;
+        wl_data_offer_add_listener(offer, &g_dataOfferListener, data);
+    },
+    // enter
+    [] (void*, struct wl_data_device*, uint32_t, struct wl_surface*, wl_fixed_t, wl_fixed_t, struct wl_data_offer*) {},
+    // leave
+    [] (void*, struct wl_data_device*) {},
+    // motion
+    [] (void*, struct wl_data_device*, uint32_t, wl_fixed_t, wl_fixed_t) {},
+    // drop
+    [] (void*, struct wl_data_device*) {},
+    // selection
+    [] (void*, struct wl_data_device*, wl_data_offer*) {},
+};
+
+PasteboardWayland::PasteboardWayland()
+{
+    ViewBackend::WaylandDisplay* display = &ViewBackend::WaylandDisplay::singleton();
+
+    if (!display->interfaces().data_device_manager)
+        return;
+
+    m_dataDevice = wl_data_device_manager_get_data_device(display->interfaces().data_device_manager, display->interfaces().seat);
+    wl_data_device_add_listener(m_dataDevice, &g_dataDeviceListener, &m_dataDeviceData);
+}
+
+PasteboardWayland::~PasteboardWayland()
+{
+    if (m_dataDeviceData.data_offer)
+        wl_data_offer_destroy(m_dataDeviceData.data_offer);
+    m_dataDeviceData.dataTypes.clear();
+
+    wl_data_device_destroy(m_dataDevice);
+}
+
+std::vector<std::string> PasteboardWayland::getTypes()
+{
+    std::vector<std::string> types;
+    for (auto dataType: m_dataDeviceData.dataTypes)
+        types.push_back(dataType);
+    return types;
+}
+
+std::string PasteboardWayland::getString(const std::string pasteboardType)
+{
+    for (auto dataType: m_dataDeviceData.dataTypes)
+    {
+        if (dataType == pasteboardType) {
+            int pipefd[2];
+            // FIXME: Should probably handle this error somehow.
+            if (pipe2(pipefd, O_CLOEXEC) == -1)
+                return std::string();
+            wl_data_offer_receive(m_dataDeviceData.data_offer, dataType.c_str(), pipefd[1]);
+            close(pipefd[1]);
+            wl_display_roundtrip(ViewBackend::WaylandDisplay::singleton().display());
+            char buf[1024];
+            std::string readString;
+            ssize_t length;
+            do {
+                length = read(pipefd[0], buf, 1024);
+                readString.append(buf, length);
+            } while (length > 0);
+            close(pipefd[0]);
+            return readString;
+        }
+    }
+    return std::string();
+}
+
+const struct wl_data_source_listener g_dataSourceListener = {
+    // target
+    [] (void*, struct wl_data_source*, const char*) {},
+    // send
+    [] (void* data, struct wl_data_source* source, const char* mime_type, int32_t fd)
+    {
+        auto* dataSourceData = static_cast<PasteboardWayland::DataSourceData*>(data);
+        assert(dataSourceData->data_source == source);
+        assert(!dataSourceData->dataMap.count(mime_type));
+
+        // FIXME: Should probably do the same for all text mimetypes.
+        if (strcmp(mime_type, "text/plain;charset=utf-8") == 0) {
+            std::string stringToSend(*static_cast<std::string*>(dataSourceData->dataMap[mime_type]));
+            const char* p = stringToSend.data();
+            ssize_t length = stringToSend.size();
+            ssize_t written = 0;
+            while (length > 0 && written != -1) {
+                written = write(fd, p, length);
+                p += written;
+                length -= written;
+            }
+            close(fd);
+            wl_display_roundtrip(ViewBackend::WaylandDisplay::singleton().display());
+        } else
+            return; // Eventually assert if we don't have a handler for a mimetype we are offering.
+    },
+    // cancelled
+    [] (void* data, struct wl_data_source* source)
+    {
+        auto* dataSourceData = static_cast<PasteboardWayland::DataSourceData*>(data);
+        assert(dataSourceData->data_source == source);
+        wl_data_source_destroy(source);
+        dataSourceData->data_source = nullptr;
+        dataSourceData->dataMap.clear();
+    }
+};
+
+void PasteboardWayland::write(const std::map<std::string, void*> dataMap)
+{
+    if (m_dataSourceData.data_source)
+        wl_data_source_destroy(m_dataSourceData.data_source);
+
+    m_dataSourceData.dataMap = dataMap;
+
+    ViewBackend::WaylandDisplay* display = &ViewBackend::WaylandDisplay::singleton();
+    m_dataSourceData.data_source = wl_data_device_manager_create_data_source(display->interfaces().data_device_manager);
+
+    for (auto dataPair: dataMap)
+        wl_data_source_offer(m_dataSourceData.data_source, dataPair.first.c_str());
+
+    wl_data_source_add_listener(m_dataSourceData.data_source, &g_dataSourceListener, &m_dataSourceData);
+    wl_data_device_set_selection(m_dataDevice, m_dataSourceData.data_source, display->singleton().serial());
+}
+
+void PasteboardWayland::write(const std::string pasteboardType, const std::string stringToWrite)
+{
+    std::map<std::string, void*> dataMap;
+    dataMap[pasteboardType] = static_cast<void*>(new std::string(stringToWrite));
+    write(dataMap);
+}
+
+} // namespace Pasteboard
+
+} // namespace WPE
+
+#endif // WPE_BACKEND(WAYLAND)

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
@@ -142,7 +142,7 @@ const struct wl_data_source_listener g_dataSourceListener = {
         assert(!dataSourceData.dataMap.count(mime_type));
 
         if (strncmp(mime_type, "text/", 5) == 0) {
-            std::string stringToSend(*static_cast<std::string*>(dataSourceData->dataMap[mime_type]));
+            std::string stringToSend = dataSourceData.dataMap[mime_type];
             const char* p = stringToSend.data();
             ssize_t length = stringToSend.size();
             ssize_t written = 0;
@@ -167,7 +167,7 @@ const struct wl_data_source_listener g_dataSourceListener = {
     }
 };
 
-void PasteboardWayland::write(const std::map<std::string, void*> dataMap)
+void PasteboardWayland::write(const std::map<std::string, std::string> dataMap)
 {
     if (m_dataSourceData.data_source)
         wl_data_source_destroy(m_dataSourceData.data_source);
@@ -186,8 +186,8 @@ void PasteboardWayland::write(const std::map<std::string, void*> dataMap)
 
 void PasteboardWayland::write(const std::string pasteboardType, const std::string stringToWrite)
 {
-    std::map<std::string, void*> dataMap;
-    dataMap[pasteboardType] = static_cast<void*>(new std::string(stringToWrite));
+    std::map<std::string, std::string> dataMap;
+    dataMap[pasteboardType] = stringToWrite;
     write(dataMap);
 }
 

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
@@ -177,7 +177,7 @@ void PasteboardWayland::write(const std::map<std::string, void*> dataMap)
     ViewBackend::WaylandDisplay* display = &ViewBackend::WaylandDisplay::singleton();
     m_dataSourceData.data_source = wl_data_device_manager_create_data_source(display->interfaces().data_device_manager);
 
-    for (auto dataPair: dataMap)
+    for (auto dataPair : dataMap)
         wl_data_source_offer(m_dataSourceData.data_source, dataPair.first.c_str());
 
     wl_data_source_add_listener(m_dataSourceData.data_source, &g_dataSourceListener, &m_dataSourceData);

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.cpp
@@ -168,7 +168,7 @@ const struct wl_data_source_listener g_dataSourceListener = {
     }
 };
 
-void PasteboardWayland::write(const std::map<std::string, std::string> dataMap)
+void PasteboardWayland::write(std::map<std::string, std::string>&& dataMap)
 {
     if (m_dataSourceData.data_source)
         wl_data_source_destroy(m_dataSourceData.data_source);
@@ -178,18 +178,18 @@ void PasteboardWayland::write(const std::map<std::string, std::string> dataMap)
     ViewBackend::WaylandDisplay& display = ViewBackend::WaylandDisplay::singleton();
     m_dataSourceData.data_source = wl_data_device_manager_create_data_source(display.interfaces().data_device_manager);
 
-    for (auto dataPair : dataMap)
+    for (auto dataPair : m_dataSourceData.dataMap)
         wl_data_source_offer(m_dataSourceData.data_source, dataPair.first.c_str());
 
     wl_data_source_add_listener(m_dataSourceData.data_source, &g_dataSourceListener, &m_dataSourceData);
     wl_data_device_set_selection(m_dataDevice, m_dataSourceData.data_source, display.singleton().serial());
 }
 
-void PasteboardWayland::write(const std::string pasteboardType, const std::string stringToWrite)
+void PasteboardWayland::write(std::string&& pasteboardType, std::string&& stringToWrite)
 {
     std::map<std::string, std::string> dataMap;
     dataMap[pasteboardType] = stringToWrite;
-    write(dataMap);
+    write(std::move(dataMap));
 }
 
 } // namespace Pasteboard

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.h
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPE_Pasteboard_PasteboardWayland_h
+#define WPE_Pasteboard_PasteboardWayland_h
+
+#if WPE_BACKEND(WAYLAND)
+
+#include <WPE/Pasteboard/Pasteboard.h>
+#include <list>
+#include <map>
+#include <memory>
+#include <vector>
+
+struct wl_data_device;
+struct wl_data_offer;
+struct wl_data_source;
+
+namespace WPE {
+
+namespace Pasteboard {
+
+class PasteboardWayland final : public Pasteboard {
+public:
+    std::vector<std::string> getTypes() override;
+    std::string getString(const std::string) override;
+    void write(const std::map<std::string, void*>) override;
+    void write(const std::string, const std::string) override;
+
+    PasteboardWayland();
+    ~PasteboardWayland();
+
+    struct DataDeviceData {
+    DataDeviceData() : data_offer(nullptr) {}
+        wl_data_offer* data_offer;
+        std::list<std::string> dataTypes;
+    };
+
+    struct DataSourceData {
+        DataSourceData() : data_source(nullptr) {}
+        wl_data_source* data_source;
+        std::map<std::string, void*> dataMap;
+    };
+
+private:
+
+    struct wl_data_device* m_dataDevice { nullptr };
+    DataDeviceData m_dataDeviceData;
+    DataSourceData m_dataSourceData;
+};
+
+} // namespace Pasteboard
+
+} // namespace WPE
+
+#endif //WPE_BACKEND(WAYLAND)
+
+#endif // WPE_ViewBackend_PasteboardWayland_h

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.h
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.h
@@ -46,7 +46,7 @@ class PasteboardWayland final : public Pasteboard {
 public:
     std::vector<std::string> getTypes() override;
     std::string getString(const std::string) override;
-    void write(const std::map<std::string, void*>) override;
+    void write(const std::map<std::string, std::string>) override;
     void write(const std::string, const std::string) override;
 
     PasteboardWayland();
@@ -61,7 +61,7 @@ public:
     struct DataSourceData {
         DataSourceData() : data_source(nullptr) {}
         wl_data_source* data_source;
-        std::map<std::string, void*> dataMap;
+        std::map<std::string, std::string> dataMap;
     };
 
 private:

--- a/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.h
+++ b/Source/WPE/Source/Pasteboard/Wayland/PasteboardWayland.h
@@ -46,8 +46,8 @@ class PasteboardWayland final : public Pasteboard {
 public:
     std::vector<std::string> getTypes() override;
     std::string getString(const std::string) override;
-    void write(const std::map<std::string, std::string>) override;
-    void write(const std::string, const std::string) override;
+    void write(std::map<std::string, std::string>&&) override;
+    void write(std::string&&, std::string&&) override;
 
     PasteboardWayland();
     ~PasteboardWayland();

--- a/Source/WPE/Source/ViewBackend/Wayland/ViewBackendWayland.cpp
+++ b/Source/WPE/Source/ViewBackend/Wayland/ViewBackendWayland.cpp
@@ -36,6 +36,7 @@
 #include "ivi-application-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 #include "wayland-drm-client-protocol.h"
+#include <WPE/Pasteboard/Pasteboard.h>
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
@@ -113,6 +114,8 @@ ViewBackendWayland::ViewBackendWayland()
             m_surface);
         ivi_surface_add_listener(m_iviSurface, &g_iviSurfaceListener, &m_resizingData);
     }
+
+    Pasteboard::Pasteboard::singleton();
 }
 
 ViewBackendWayland::~ViewBackendWayland()

--- a/Source/WPE/Source/ViewBackend/Wayland/ViewBackendWayland.cpp
+++ b/Source/WPE/Source/ViewBackend/Wayland/ViewBackendWayland.cpp
@@ -115,6 +115,7 @@ ViewBackendWayland::ViewBackendWayland()
         ivi_surface_add_listener(m_iviSurface, &g_iviSurfaceListener, &m_resizingData);
     }
 
+    // Ensure the Pasteboard singleton is constructed early.
     Pasteboard::Pasteboard::singleton();
 }
 

--- a/Source/WPE/Source/ViewBackend/Wayland/WaylandDisplay.cpp
+++ b/Source/WPE/Source/ViewBackend/Wayland/WaylandDisplay.cpp
@@ -104,6 +104,9 @@ const struct wl_registry_listener g_registryListener = {
         if (!std::strcmp(interface, "wl_compositor"))
             interfaces.compositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, 1));
 
+        if (!std::strcmp(interface, "wl_data_device_manager"))
+            interfaces.data_device_manager = static_cast<struct wl_data_device_manager*>(wl_registry_bind(registry, name, &wl_data_device_manager_interface, 2));
+
         if (!std::strcmp(interface, "wl_drm"))
             interfaces.drm = static_cast<struct wl_drm*>(wl_registry_bind(registry, name, &wl_drm_interface, 2));
 
@@ -496,6 +499,8 @@ WaylandDisplay::~WaylandDisplay()
 
     if (m_interfaces.compositor)
         wl_compositor_destroy(m_interfaces.compositor);
+    if (m_interfaces.data_device_manager)
+        wl_data_device_manager_destroy(m_interfaces.data_device_manager);
     if (m_interfaces.drm)
         wl_drm_destroy(m_interfaces.drm);
     if (m_interfaces.seat)
@@ -504,7 +509,7 @@ WaylandDisplay::~WaylandDisplay()
         xdg_shell_destroy(m_interfaces.xdg);
     if (m_interfaces.ivi_application)
         ivi_application_destroy(m_interfaces.ivi_application);
-    m_interfaces = { nullptr, nullptr, nullptr, nullptr, nullptr };
+    m_interfaces = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
 
     if (m_registry)
         wl_registry_destroy(m_registry);

--- a/Source/WPE/Source/ViewBackend/Wayland/WaylandDisplay.h
+++ b/Source/WPE/Source/ViewBackend/Wayland/WaylandDisplay.h
@@ -64,6 +64,8 @@ public:
 
     struct wl_display* display() const { return m_display; }
 
+    uint32_t serial() const { return m_seatData.serial; }
+
     struct Interfaces {
         struct wl_compositor* compositor;
         struct wl_drm* drm;
@@ -116,6 +118,8 @@ public:
             uint32_t state;
             uint32_t eventSource;
         } repeatData { 0, 0, 0, 0 };
+
+        uint32_t serial;
     };
 
     void registerInputClient(struct wl_surface*, Input::Client*);

--- a/Source/WPE/Source/ViewBackend/Wayland/WaylandDisplay.h
+++ b/Source/WPE/Source/ViewBackend/Wayland/WaylandDisplay.h
@@ -38,6 +38,7 @@
 
 struct ivi_application;
 struct wl_compositor;
+struct wl_data_device_manager;
 struct wl_display;
 struct wl_drm;
 struct wl_keyboard;
@@ -68,6 +69,7 @@ public:
 
     struct Interfaces {
         struct wl_compositor* compositor;
+        struct wl_data_device_manager* data_device_manager;
         struct wl_drm* drm;
         struct wl_seat* seat;
         struct xdg_shell* xdg;

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -230,6 +230,7 @@ list(APPEND WebCore_SOURCES
     platform/wpe/MainThreadSharedTimerWPE.cpp
     platform/wpe/PasteboardWPE.cpp
     platform/wpe/PlatformKeyboardEventWPE.cpp
+    platform/wpe/PlatformPasteboardWPE.cpp
     platform/wpe/PlatformScreenWPE.cpp
     platform/wpe/RenderThemeWPE.cpp
     platform/wpe/SSLKeyGeneratorWPE.cpp
@@ -276,6 +277,7 @@ list(APPEND WebCore_LIBRARIES
     ${PNG_LIBRARIES}
     ${SQLITE_LIBRARIES}
     ${WEBP_LIBRARIES}
+    WPE
 )
 
 list(APPEND WebCore_INCLUDE_DIRECTORIES
@@ -300,6 +302,7 @@ list(APPEND WebCore_INCLUDE_DIRECTORIES
     ${PNG_INCLUDE_DIRS}
     ${SQLITE_INCLUDE_DIR}
     ${WEBP_INCLUDE_DIRS}
+    ${WPE_DIR}
 )
 
 if (ENABLE_WEB_AUDIO)

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -68,7 +68,7 @@ enum ShouldSerializeSelectedTextForDataTransfer { DefaultSelectedTextType, Inclu
 // For writing to the pasteboard. Generally sorted with the richest formats on top.
 
 struct PasteboardWebContent {
-#if !(PLATFORM(EFL) || PLATFORM(GTK) || PLATFORM(WIN))
+#if !(PLATFORM(EFL) || PLATFORM(GTK) || PLATFORM(WIN) || PLATFORM(WPE))
     WEBCORE_EXPORT PasteboardWebContent();
     WEBCORE_EXPORT ~PasteboardWebContent();
     bool canSmartCopyOrDelete;

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -85,6 +85,10 @@ struct PasteboardWebContent {
     String markup;
     GRefPtr<GClosure> callback;
 #endif
+#if PLATFORM(WPE)
+    String text;
+    String markup;
+#endif
 };
 
 struct PasteboardURL {

--- a/Source/WebCore/platform/PasteboardStrategy.h
+++ b/Source/WebCore/platform/PasteboardStrategy.h
@@ -71,6 +71,7 @@ public:
 #if PLATFORM(WPE)
     virtual void getTypes(Vector<String>& types) = 0;
     virtual String readStringFromPasteboard(int index, const String& pasteboardType) = 0;
+    virtual void writeToPasteboard(const PasteboardWebContent&) = 0;
     virtual void writeToPasteboard(const String& pasteboardType, const String&) = 0;
 #endif
 

--- a/Source/WebCore/platform/PasteboardStrategy.h
+++ b/Source/WebCore/platform/PasteboardStrategy.h
@@ -68,6 +68,12 @@ public:
     virtual long setPathnamesForType(const Vector<String>&, const String& pasteboardType, const String& pasteboardName) = 0;
     virtual long setStringForType(const String&, const String& pasteboardType, const String& pasteboardName) = 0;
 #endif
+#if PLATFORM(WPE)
+    virtual void getTypes(Vector<String>& types) = 0;
+    virtual String readStringFromPasteboard(int index, const String& pasteboardType) = 0;
+    virtual void writeToPasteboard(const String& pasteboardType, const String&) = 0;
+#endif
+
 protected:
     virtual ~PasteboardStrategy()
     {

--- a/Source/WebCore/platform/PlatformPasteboard.h
+++ b/Source/WebCore/platform/PlatformPasteboard.h
@@ -28,7 +28,6 @@
 
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/platform/PlatformPasteboard.h
+++ b/Source/WebCore/platform/PlatformPasteboard.h
@@ -28,6 +28,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 
@@ -37,6 +38,14 @@ OBJC_CLASS NSPasteboard;
 
 #if PLATFORM(IOS)
 OBJC_CLASS UIPasteboard;
+#endif
+
+#if PLATFORM(WPE)
+namespace WPE {
+namespace Pasteboard {
+class Pasteboard;
+}
+}
 #endif
 
 namespace WebCore {
@@ -51,7 +60,7 @@ class PlatformPasteboard {
 public:
     // FIXME: probably we don't need a constructor that takes a pasteboard name for iOS.
     WEBCORE_EXPORT explicit PlatformPasteboard(const String& pasteboardName);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(WPE)
     WEBCORE_EXPORT PlatformPasteboard();
 #endif
     WEBCORE_EXPORT static String uniqueName();
@@ -87,6 +96,9 @@ private:
 #endif
 #if PLATFORM(IOS)
     RetainPtr<UIPasteboard> m_pasteboard;
+#endif
+#if PLATFORM(WPE)
+    std::shared_ptr<WPE::Pasteboard::Pasteboard> m_pasteboard;
 #endif
 };
 

--- a/Source/WebCore/platform/wpe/PasteboardWPE.cpp
+++ b/Source/WebCore/platform/wpe/PasteboardWPE.cpp
@@ -83,10 +83,6 @@ void Pasteboard::read(PasteboardPlainText& text)
     text.text = platformStrategies()->pasteboardStrategy()->readStringFromPasteboard(0, "text/plain;charset=utf-8");
 }
 
-void Pasteboard::read(PasteboardWebContentReader&)
-{
-}
-
 void Pasteboard::write(const PasteboardURL& url)
 {
     platformStrategies()->pasteboardStrategy()->writeToPasteboard("text/plain;charset=utf-8", url.url.string());
@@ -96,8 +92,9 @@ void Pasteboard::write(const PasteboardImage&)
 {
 }
 
-void Pasteboard::write(const PasteboardWebContent&)
+void Pasteboard::write(const PasteboardWebContent& content)
 {
+    platformStrategies()->pasteboardStrategy()->writeToPasteboard(content);
 }
 
 Vector<String> Pasteboard::readFilenames()

--- a/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
@@ -61,9 +61,9 @@ String PlatformPasteboard::readString(int, const String& pasteboardType)
 
 void PlatformPasteboard::write(const PasteboardWebContent& content)
 {
-    std::map<std::string, void*> contentMap;
-    contentMap["text/plain;charset=utf-8"] = static_cast<void*>(new std::string(content.text.utf8().data()));
-    contentMap["text/html;charset=utf-8"] = static_cast<void*>(new std::string(content.markup.utf8().data()));
+    std::map<std::string, std::string> contentMap;
+    contentMap["text/plain;charset=utf-8"] = std::string(content.text.utf8().data());
+    contentMap["text/html;charset=utf-8"] = std::string(content.markup.utf8().data());
     m_pasteboard->write(contentMap);
 }
 

--- a/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
@@ -29,6 +29,7 @@
 #include "PlatformPasteboard.h"
 #include <WPE/Pasteboard/Pasteboard.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/Assertions.h>
 
 #include <map>
 
@@ -37,11 +38,13 @@ namespace WebCore {
 PlatformPasteboard::PlatformPasteboard(const String&)
     : m_pasteboard(WPE::Pasteboard::Pasteboard::singleton())
 {
+    ASSERT(m_pasteboard);
 }
 
 PlatformPasteboard::PlatformPasteboard()
     : m_pasteboard(WPE::Pasteboard::Pasteboard::singleton())
 {
+    ASSERT(m_pasteboard);
 }
 
 void PlatformPasteboard::getTypes(Vector<String>& types)

--- a/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Pasteboard.h"
+#include "PlatformPasteboard.h"
+#include <WPE/Pasteboard/Pasteboard.h>
+#include <wtf/text/WTFString.h>
+
+#include <map>
+
+namespace WebCore {
+
+PlatformPasteboard::PlatformPasteboard(const String&)
+    : m_pasteboard(WPE::Pasteboard::Pasteboard::singleton())
+{
+}
+
+PlatformPasteboard::PlatformPasteboard()
+    : m_pasteboard(WPE::Pasteboard::Pasteboard::singleton())
+{
+}
+
+void PlatformPasteboard::getTypes(Vector<String>& types)
+{
+    auto pasteboardTypes = m_pasteboard->getTypes();
+    for (auto type: pasteboardTypes)
+        types.append(type.c_str());
+}
+
+String PlatformPasteboard::readString(int, const String& pasteboardType)
+{
+    return String(m_pasteboard->getString(pasteboardType.utf8().data()).c_str());
+}
+
+void PlatformPasteboard::write(const String& pasteboardType, const String& stringToWrite)
+{
+    m_pasteboard->write(pasteboardType.utf8().data(), stringToWrite.utf8().data());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
@@ -56,6 +56,14 @@ String PlatformPasteboard::readString(int, const String& pasteboardType)
     return String(m_pasteboard->getString(pasteboardType.utf8().data()).c_str());
 }
 
+void PlatformPasteboard::write(const PasteboardWebContent& content)
+{
+    std::map<std::string, void*> contentMap;
+    contentMap["text/plain;charset=utf-8"] = static_cast<void*>(new std::string(content.text.utf8().data()));
+    contentMap["text/html;charset=utf-8"] = static_cast<void*>(new std::string(content.markup.utf8().data()));
+    m_pasteboard->write(contentMap);
+}
+
 void PlatformPasteboard::write(const String& pasteboardType, const String& stringToWrite)
 {
     m_pasteboard->write(pasteboardType.utf8().data(), stringToWrite.utf8().data());

--- a/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformPasteboardWPE.cpp
@@ -64,7 +64,7 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
     std::map<std::string, std::string> contentMap;
     contentMap["text/plain;charset=utf-8"] = std::string(content.text.utf8().data());
     contentMap["text/html;charset=utf-8"] = std::string(content.markup.utf8().data());
-    m_pasteboard->write(contentMap);
+    m_pasteboard->write(std::move(contentMap));
 }
 
 void PlatformPasteboard::write(const String& pasteboardType, const String& stringToWrite)

--- a/Source/WebKit2/PlatformWPE.cmake
+++ b/Source/WebKit2/PlatformWPE.cmake
@@ -124,6 +124,7 @@ list(APPEND WebKit2_SOURCES
     UIProcess/wpe/TextCheckerWPE.cpp
     UIProcess/wpe/WebInspectorProxyWPE.cpp
     UIProcess/wpe/WebPageProxyWPE.cpp
+    UIProcess/wpe/WebPasteboardProxyWPE.cpp
     UIProcess/wpe/WebPreferencesWPE.cpp
     UIProcess/wpe/WebProcessPoolWPE.cpp
     UIProcess/wpe/WebProcessProxyWPE.cpp

--- a/Source/WebKit2/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit2/Shared/WebCoreArgumentCoders.cpp
@@ -78,10 +78,13 @@
 #if PLATFORM(IOS)
 #include <WebCore/FloatQuad.h>
 #include <WebCore/InspectorOverlay.h>
-#include <WebCore/Pasteboard.h>
 #include <WebCore/SelectionRect.h>
 #include <WebCore/SharedBuffer.h>
 #endif // PLATFORM(IOS)
+
+#if PLATFORM(IOS) || PLATFORM(WPE)
+#include <WebCore/Pasteboard.h>
+#endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 #include <WebCore/MediaPlaybackTargetContext.h>
@@ -1295,6 +1298,23 @@ bool ArgumentCoder<PasteboardImage>::decode(ArgumentDecoder& decoder, Pasteboard
 }
 
 #endif
+
+#if PLATFORM(WPE)
+void ArgumentCoder<PasteboardWebContent>::encode(ArgumentEncoder& encoder, const PasteboardWebContent& content)
+{
+    encoder << content.text;
+    encoder << content.markup;
+}
+
+bool ArgumentCoder<PasteboardWebContent>::decode(ArgumentDecoder& decoder, PasteboardWebContent& content)
+{
+    if (!decoder.decode(content.text))
+        return false;
+    if (!decoder.decode(content.markup))
+        return false;
+    return true;
+}
+#endif // PLATFORM(WPE)
 
 void ArgumentCoder<DictationAlternative>::encode(ArgumentEncoder& encoder, const DictationAlternative& dictationAlternative)
 {

--- a/Source/WebKit2/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit2/Shared/WebCoreArgumentCoders.h
@@ -106,6 +106,12 @@ struct ViewportArguments;
 }
 #endif
 
+#if PLATFORM(WPE)
+namespace WebCore {
+struct PasteboardWebContents;
+}
+#endif
+
 #if ENABLE(CONTENT_FILTERING)
 namespace WebCore {
 class ContentFilterUnblockHandler;
@@ -318,6 +324,13 @@ template<> struct ArgumentCoder<WebCore::PasteboardWebContent> {
 template<> struct ArgumentCoder<WebCore::PasteboardImage> {
     static void encode(ArgumentEncoder&, const WebCore::PasteboardImage&);
     static bool decode(ArgumentDecoder&, WebCore::PasteboardImage&);
+};
+#endif
+
+#if PLATFORM(WPE)
+template<> struct ArgumentCoder<WebCore::PasteboardWebContent> {
+    static void encode(ArgumentEncoder&, const WebCore::PasteboardWebContent&);
+    static bool decode(ArgumentDecoder&, WebCore::PasteboardWebContent&);
 };
 #endif
 

--- a/Source/WebKit2/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit2/UIProcess/WebPasteboardProxy.h
@@ -81,6 +81,12 @@ private:
     void setPasteboardStringForType(const String& pasteboardName, const String& pasteboardType, const String&, uint64_t& newChangeCount);
     void setPasteboardBufferForType(const String& pasteboardName, const String& pasteboardType, const SharedMemory::Handle&, uint64_t size, uint64_t& newChangeCount);
 #endif
+
+#if PLATFORM(WPE)
+    void getPasteboardTypes(Vector<String>& pasteboardTypes);
+    void readStringFromPasteboard(uint64_t index, const String& pasteboardType, WTF::String&);
+    void writeStringToPasteboard(const String& pasteboardType, const String&);
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit2/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit2/UIProcess/WebPasteboardProxy.h
@@ -85,6 +85,7 @@ private:
 #if PLATFORM(WPE)
     void getPasteboardTypes(Vector<String>& pasteboardTypes);
     void readStringFromPasteboard(uint64_t index, const String& pasteboardType, WTF::String&);
+    void writeWebContentToPasteboard(const WebCore::PasteboardWebContent&);
     void writeStringToPasteboard(const String& pasteboardType, const String&);
 #endif
 };

--- a/Source/WebKit2/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit2/UIProcess/WebPasteboardProxy.messages.in
@@ -52,6 +52,7 @@ messages -> WebPasteboardProxy {
 #if PLATFORM(WPE)
     GetPasteboardTypes() -> (Vector<String> types)
     ReadStringFromPasteboard(uint64_t index, String pasteboardType) -> (String string)
+    WriteWebContentToPasteboard(struct WebCore::PasteboardWebContent content)
     WriteStringToPasteboard(String pasteboardType, String text)
 #endif
 }

--- a/Source/WebKit2/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit2/UIProcess/WebPasteboardProxy.messages.in
@@ -48,4 +48,10 @@ messages -> WebPasteboardProxy {
     SetPasteboardStringForType(String pasteboardName, String pasteboardType, String string) -> (uint64_t changeCount)
     SetPasteboardBufferForType(String pasteboardName, String pasteboardType, WebKit::SharedMemory::Handle handle, uint64_t size) -> (uint64_t changeCount)
 #endif
+
+#if PLATFORM(WPE)
+    GetPasteboardTypes() -> (Vector<String> types)
+    ReadStringFromPasteboard(uint64_t index, String pasteboardType) -> (String string)
+    WriteStringToPasteboard(String pasteboardType, String text)
+#endif
 }

--- a/Source/WebKit2/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit2/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -42,6 +42,11 @@ void WebPasteboardProxy::readStringFromPasteboard(uint64_t index, const String& 
     value = PlatformPasteboard().readString(index, pasteboardType);
 }
 
+void WebPasteboardProxy::writeWebContentToPasteboard(const WebCore::PasteboardWebContent& content)
+{
+    PlatformPasteboard().write(content);
+}
+
 void WebPasteboardProxy::writeStringToPasteboard(const String& pasteboardType, const String& text)
 {
     PlatformPasteboard().write(pasteboardType, text);

--- a/Source/WebKit2/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit2/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebPasteboardProxy.h"
+
+#include <WebCore/PlatformPasteboard.h>
+#include <wtf/text/WTFString.h>
+
+using namespace WebCore;
+
+namespace WebKit {
+void WebPasteboardProxy::getPasteboardTypes(Vector<String>& pasteboardTypes)
+{
+    PlatformPasteboard().getTypes(pasteboardTypes);
+}
+
+void WebPasteboardProxy::readStringFromPasteboard(uint64_t index, const String& pasteboardType, WTF::String& value)
+{
+    value = PlatformPasteboard().readString(index, pasteboardType);
+}
+
+void WebPasteboardProxy::writeStringToPasteboard(const String& pasteboardType, const String& text)
+{
+    PlatformPasteboard().write(pasteboardType, text);
+}
+
+} // namespace WebKit

--- a/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -480,6 +480,11 @@ String WebPlatformStrategies::readStringFromPasteboard(int index, const String& 
     return value;
 }
 
+void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardWebContent& content)
+{
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(content), 0);
+}
+
 void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, const String& text)
 {
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPasteboardProxy::WriteStringToPasteboard(pasteboardType, text), 0);

--- a/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -466,4 +466,25 @@ long WebPlatformStrategies::changeCount()
 
 #endif // PLATFORM(COCOA)
 
+#if PLATFORM(WPE)
+
+void WebPlatformStrategies::getTypes(Vector<String>& types)
+{
+    WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardTypes(), Messages::WebPasteboardProxy::GetPasteboardTypes::Reply(types), 0);
+}
+
+String WebPlatformStrategies::readStringFromPasteboard(int index, const String& pasteboardType)
+{
+    String value;
+    WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadStringFromPasteboard(index, pasteboardType), Messages::WebPasteboardProxy::ReadStringFromPasteboard::Reply(value), 0);
+    return value;
+}
+
+void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, const String& text)
+{
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPasteboardProxy::WriteStringToPasteboard(pasteboardType, text), 0);
+}
+
+#endif // PLATFORM(WPE)
+
 } // namespace WebKit

--- a/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -100,6 +100,11 @@ private:
     virtual long setPathnamesForType(const Vector<String>&, const String& pasteboardType, const String& pasteboardName) override;
     virtual long setStringForType(const String&, const String& pasteboardType, const String& pasteboardName) override;
 #endif
+#if PLATFORM(WPE)
+    virtual void getTypes(Vector<String>& types) override;
+    virtual String readStringFromPasteboard(int index, const String& pasteboardType) override;
+    virtual void writeToPasteboard(const String& pasteboardType, const String&) override;
+#endif
 
 #if ENABLE(NETSCAPE_PLUGIN_API)
     // WebCore::PluginStrategy implementation.

--- a/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit2/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -103,6 +103,7 @@ private:
 #if PLATFORM(WPE)
     virtual void getTypes(Vector<String>& types) override;
     virtual String readStringFromPasteboard(int index, const String& pasteboardType) override;
+    virtual void writeToPasteboard(const WebCore::PasteboardWebContent&) override;
     virtual void writeToPasteboard(const String& pasteboardType, const String&) override;
 #endif
 

--- a/Source/WebKit2/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
+++ b/Source/WebKit2/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
@@ -111,13 +111,13 @@ static const KeyDownEntry keyDownEntries[] = {
     // These probably need handling somewhere else so do not execute them. The
     // 'Cut' command is removing text so let's avoid losing the user losing data
     // until we implement clipboard support wherever it should be.
-    // { VK_INSERT, CtrlKey,            "Copy"                                    },
-    // { VK_INSERT, ShiftKey,           "Paste"                                   },
-    // { VK_DELETE, ShiftKey,           "Cut"                                     },
-    // { 'C',         CtrlKey,          "Copy"                                    },
-    // { 'V',         CtrlKey,          "Paste"                                   },
-    // { 'V',         CtrlKey | ShiftKey, "PasteAndMatchStyle"                    },
-    // { 'X',         CtrlKey,          "Cut"                                     },
+    { VK_INSERT, CtrlKey,            "Copy"                                    },
+    { VK_INSERT, ShiftKey,           "Paste"                                   },
+    { VK_DELETE, ShiftKey,           "Cut"                                     },
+    { 'C',         CtrlKey,          "Copy"                                    },
+    { 'V',         CtrlKey,          "Paste"                                   },
+    { 'V',         CtrlKey | ShiftKey, "PasteAndMatchStyle"                    },
+    { 'X',         CtrlKey,          "Cut"                                     },
     { 'A',         CtrlKey,          "SelectAll"                               },
     { 'Z',         CtrlKey,          "Undo"                                    },
     { 'Z',         CtrlKey | ShiftKey, "Redo"                                  },


### PR DESCRIPTION
This is the basic implementation of the pasteboard for both Wayland and non-Wayland backends. WPE provides two Pasteboards: a Wayland-based using the data device manager interface to offer and receive data from and to Wayland clients and a private one that only works inside the WebKit client.

The WPE pasteboard lives in the UI-process (because of the UI-process being the actual Wayland client) and the WebCore pasteboard, in the web process, communicates with it using a Platform strategy. This platform strategy uses a web pasteboard proxy to be able to communicate with libwpe in the UI process.

At this point, cut/copy/paste for plain text in input fields works. More complex data types will need further work.