### PR TITLE
DOM: add ClipboardEvent

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -361,6 +361,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/ChildNode.idl
     dom/ClientRect.idl
     dom/ClientRectList.idl
+    dom/ClipboardEvent.idl
     dom/Comment.idl
     dom/CompositionEvent.idl
     dom/CustomEvent.idl

--- a/Source/WebCore/dom/ClipboardEvent.cpp
+++ b/Source/WebCore/dom/ClipboardEvent.cpp
@@ -24,9 +24,15 @@
 #include "ClipboardEvent.h"
 
 #include "DataTransfer.h"
+#include "DataTransferAccessPolicy.h"
 #include "EventNames.h"
 
 namespace WebCore {
+
+ClipboardEventInit::ClipboardEventInit()
+    : dataTransfer(DataTransfer::createForCopyAndPaste(DataTransferAccessPolicy::Writable))
+{
+}
 
 ClipboardEvent::ClipboardEvent()
 {
@@ -37,14 +43,19 @@ ClipboardEvent::ClipboardEvent(const AtomicString& eventType, bool canBubble, bo
 {
 }
 
+ClipboardEvent::ClipboardEvent(const AtomicString& eventType, ClipboardEventInit& initializer)
+    : Event(eventType, initializer)
+    , m_dataTransfer(initializer.dataTransfer)
+{
+}
+
 ClipboardEvent::~ClipboardEvent()
 {
 }
 
 EventInterface ClipboardEvent::eventInterface() const
 {
-    // Notice that there is no ClipboardEvent.idl.
-    return EventInterfaceType;
+    return ClipboardEventInterfaceType;
 }
 
 bool ClipboardEvent::isClipboardEvent() const

--- a/Source/WebCore/dom/ClipboardEvent.h
+++ b/Source/WebCore/dom/ClipboardEvent.h
@@ -30,6 +30,11 @@ namespace WebCore {
 
     class DataTransfer;
 
+    struct ClipboardEventInit : public EventInit {
+        ClipboardEventInit();
+        RefPtr<DataTransfer> dataTransfer;
+    };
+
     class ClipboardEvent final : public Event {
     public:
         virtual ~ClipboardEvent();
@@ -43,11 +48,17 @@ namespace WebCore {
             return adoptRef(*new ClipboardEvent(type, canBubbleArg, cancelableArg, clipboardArg));
         }
 
+        static Ref<ClipboardEvent> create(const AtomicString& type, ClipboardEventInit& initializer)
+        {
+            return adoptRef(*new ClipboardEvent(type, initializer));
+        }
+
         virtual DataTransfer* internalDataTransfer() const override { return m_dataTransfer.get(); }
 
     private:
         ClipboardEvent();
         ClipboardEvent(const AtomicString& type, bool canBubbleArg, bool cancelableArg, DataTransfer*);
+        ClipboardEvent(const AtomicString& type, ClipboardEventInit&);
 
         virtual EventInterface eventInterface() const override;
         virtual bool isClipboardEvent() const override;

--- a/Source/WebCore/dom/ClipboardEvent.idl
+++ b/Source/WebCore/dom/ClipboardEvent.idl
@@ -1,0 +1,5 @@
+[
+    ConstructorTemplate=Event
+] interface ClipboardEvent : Event {
+    readonly attribute DataTransfer clipboardData;
+};

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -79,6 +79,7 @@ namespace WebCore {
     macro(chargingtimechange) \
     macro(checking) \
     macro(click) \
+    macro(clipboard) \
     macro(close) \
     macro(complete) \
     macro(compositionend) \

--- a/Source/WebCore/dom/EventNames.in
+++ b/Source/WebCore/dom/EventNames.in
@@ -6,6 +6,7 @@ HTMLEvents interfaceName=Event
 AnimationEvent
 BeforeLoadEvent
 BeforeUnloadEvent
+ClipboardEvent
 CloseEvent
 CompositionEvent
 CustomEvent


### PR DESCRIPTION
The ClipboardEvent event is part of the Clipboard DOM API. Because
of the current implementation of the WebKit Pasteboard the underlying
data used comes from the system clipboard. We still need to fix this
by adding a private pasteboard as other ports do.