### PR TITLE
Enabled FTL_JIT on x86_64 builds

### DIFF
--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -455,7 +455,7 @@ my @features = (
       define => "ENABLE_XSLT", default => 1, value => \$xsltSupport },
 
     { option => "ftl-jit", desc => "Toggle FTLJIT support",
-      define => "ENABLE_FTL_JIT", default => (isX86_64() && (isGtk() || isEfl())) , value => \$ftlJITSupport },
+      define => "ENABLE_FTL_JIT", default => (isX86_64() && (isGtk() || isEfl() || isWPE())) , value => \$ftlJITSupport },
 );
 
 sub getFeatureOptionList()


### PR DESCRIPTION
Following Apple's Mac OSX, Gtk+ and EFL ports, patch enables the FTL JIT
feature on x86_64 linux builds.

FTL is one of the most recent major JSC optimization, designed to be 64bit only,
and there is currently no reason for it not to be enabled on w4w master branch.

Just to show some differences, with FTL JIT enabled on W4W trunk as of
2016/Jun/30 (SHA ea3f80fa), JetStream scored 40 points higher with FTL JIT
enabled, and the whole benchmark execution time was 30s less.