### PR TITLE
WPE: Load a backend with a generic name by default

### DIFF
--- a/Source/ThirdParty/WPE-mesa/CMakeLists.txt
+++ b/Source/ThirdParty/WPE-mesa/CMakeLists.txt
@@ -68,3 +68,10 @@ add_library(WPE-mesa SHARED ${WPE_MESA_SOURCES})
 target_include_directories(WPE-mesa PRIVATE ${WPE_MESA_INCLUDE_DIRECTORIES})
 target_link_libraries(WPE-mesa ${WPE_MESA_LIBRARIES})
 install(TARGETS WPE-mesa DESTINATION "${LIB_INSTALL_DIR}")
+
+# Create a libWPE-backend.so symlink to libWPE-mesa.so and install it.
+add_custom_command(TARGET WPE-mesa
+                   POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E create_symlink libWPE-mesa.so ${CMAKE_BINARY_DIR}/lib/libWPE-backend.so
+                  )
+install(FILES ${CMAKE_BINARY_DIR}/lib/libWPE-backend.so DESTINATION "${LIB_INSTALL_DIR}")

--- a/Source/ThirdParty/WPE/src/loader.c
+++ b/Source/ThirdParty/WPE/src/loader.c
@@ -43,10 +43,7 @@ load_impl_library()
         abort();
     }
 #else
-    // FIXME:
-    // 1. should use a more generic name, usable via a symbolic link to the
-    //    platform-specific libraries,
-    static const char library_name[] = "libWPE-mesa.so";
+    static const char library_name[] = "libWPE-backend.so";
 
     // Get the impl library from an environment variable.
     char* env_library_name = getenv("WPE_BACKEND_LIBRARY");
@@ -57,10 +54,10 @@ load_impl_library()
             abort();
         }
     } else {
-        // Load libWPE-mesa.so by defauly.
+        // Load libWPE-backend.so by defauly.
         s_impl_library = dlopen(library_name, RTLD_NOW);
         if (!s_impl_library) {
-            fprintf(stderr, "wpe: could not load the impl library: %s\n", dlerror());
+            fprintf(stderr, "wpe: could not load the impl library. Is there any backend installed?: %s\n", dlerror());
             abort();
         }
     }


### PR DESCRIPTION
If no backend has been defined at compile-time or runtime, WPE
will load libWPE-backend.so by default. The backends are now
expected to create a symlink pointing to their loadable module.

See WPE-mesa/CMakeLists.txt on how to create and install the
symbolic link.